### PR TITLE
Added support for evaluate javascript callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ state.cookieManager.removeAllCookies()
 navigator.evaluateJavaScript("document.title = 'Hello'")
 ```
 
-Desktop is currently **fire-and-forget**.
-
 ---
 
 ### JS ↔ Kotlin bridge 🌉

--- a/webview-compose/src/androidMain/kotlin/io/github/kdroidfilter/webview/web/AndroidWebView.kt
+++ b/webview-compose/src/androidMain/kotlin/io/github/kdroidfilter/webview/web/AndroidWebView.kt
@@ -74,8 +74,12 @@ internal class AndroidWebView(
 
     override fun stopLoading() = webView.stopLoading()
 
-    override fun evaluateJavaScript(script: String) {
-        webView.evaluateJavascript(script, null)
+    override fun evaluateJavaScript(script: String, callback: ((String) -> Unit)?) {
+        val androidScript = "javascript:$script"
+        KLogger.d {
+            "evaluateJavaScript: $androidScript"
+        }
+        webView.evaluateJavascript(androidScript, callback)
     }
 
     override fun injectJsBridge() {

--- a/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/web/IWebView.kt
+++ b/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/web/IWebView.kt
@@ -47,6 +47,7 @@ interface IWebView {
 
     fun evaluateJavaScript(
         script: String,
+        callback: ((String) -> Unit)? = null
     )
 
     suspend fun loadContent(content: WebContent) {

--- a/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/web/WebViewNavigator.kt
+++ b/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/web/WebViewNavigator.kt
@@ -45,6 +45,7 @@ class WebViewNavigator(
 
         data class EvaluateJavaScript(
             val script: String,
+            val callback: ((String) -> Unit)? = null
         ) : NavigationEvent
     }
 
@@ -91,7 +92,7 @@ class WebViewNavigator(
                         )
 
                     is NavigationEvent.LoadHtmlFile -> loadHtmlFile(event.fileName, event.readType)
-                    is NavigationEvent.EvaluateJavaScript -> evaluateJavaScript(event.script)
+                    is NavigationEvent.EvaluateJavaScript -> evaluateJavaScript(event.script, event.callback)
                 }
             }
         }
@@ -134,8 +135,9 @@ class WebViewNavigator(
 
     fun evaluateJavaScript(
         script: String,
+        callback: ((String) -> Unit)? = null
     ) {
-        coroutineScope.launch { navigationEvents.emit(NavigationEvent.EvaluateJavaScript(script)) }
+        coroutineScope.launch { navigationEvents.emit(NavigationEvent.EvaluateJavaScript(script, callback)) }
     }
 
     fun navigateBack() {

--- a/webview-compose/src/iosMain/kotlin/io/github/kdroidfilter/webview/web/IOSWebView.kt
+++ b/webview-compose/src/iosMain/kotlin/io/github/kdroidfilter/webview/web/IOSWebView.kt
@@ -188,8 +188,16 @@ internal class IOSWebView(
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    override fun evaluateJavaScript(script: String) {
-        webView.evaluateJavaScript(script, completionHandler = null)
+    override fun evaluateJavaScript(script: String, callback: ((String) -> Unit)?) {
+        webView.evaluateJavaScript(script) { result, error ->
+            if (callback == null) return@evaluateJavaScript
+            if (error != null) {
+                KLogger.e { "evaluateJavaScript error: $error" }
+                callback.invoke(error.localizedDescription())
+            } else {
+                callback.invoke(result?.toString() ?: "")
+            }
+        }
     }
 
     override fun injectJsBridge() {

--- a/webview-compose/src/jvmMain/kotlin/io/github/kdroidfilter/webview/web/DesktopWebView.kt
+++ b/webview-compose/src/jvmMain/kotlin/io/github/kdroidfilter/webview/web/DesktopWebView.kt
@@ -99,10 +99,13 @@ internal class DesktopWebView(
 
     override fun stopLoading() = webView.stopLoading()
 
-    override fun evaluateJavaScript(
-        script: String,
-    ) {
-        webView.evaluateJavaScript(script)
+    override fun evaluateJavaScript(script: String, callback: ((String) -> Unit)?) {
+        KLogger.d {
+            "evaluateJavaScript: $script"
+        }
+        webView.evaluateJavaScript(script) { result ->
+            callback?.invoke(result)
+        }
     }
 
     override fun injectJsBridge() {


### PR DESCRIPTION
Uses `evaluate_script_with_callback` instead `evaluate_script`.
Also added `callback: ((String) -> Unit)? = null` to  `evaluateJavaScript`.