### PR TITLE
ci: add PR build check workflow for all platforms

### DIFF
--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -1,0 +1,63 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-rust-macos-aarch64:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust library
+        working-directory: wrywebview
+        run: cargo build --release --target aarch64-apple-darwin
+
+  build-rust-macos-x86_64:
+    runs-on: macos-15-intel
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust library
+        working-directory: wrywebview
+        run: cargo build --release --target x86_64-apple-darwin
+
+  build-rust-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust library
+        working-directory: wrywebview
+        run: cargo build --release --target x86_64-unknown-linux-gnu
+
+  build-rust-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust library
+        working-directory: wrywebview
+        run: cargo build --release --target x86_64-pc-windows-msvc


### PR DESCRIPTION
## Summary
- Add GitHub workflow that runs on every PR to main
- Builds Rust library on all 4 platforms:
  - macOS aarch64 (macos-latest)
  - macOS x86_64 (macos-15-intel)
  - Linux x86_64 (ubuntu-latest)
  - Windows x86_64 (windows-latest)
- Uses the same build configuration as the publish workflow

## Test plan
- [x] Create a test PR to verify the workflow runs correctly