### PR TITLE
make native logger and wry-panel logger bridged

### DIFF
--- a/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/WryWebViewPanel.kt
+++ b/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/WryWebViewPanel.kt
@@ -684,7 +684,7 @@ class WryWebViewPanel(
             }
         }
 
-        val NATIVE_LOGGER: (String) -> Unit = { System.err.println(it) }
+        var NATIVE_LOGGER: (String) -> Unit = { System.err.println(it) }
 
         init {
             setNativeLogger(


### PR DESCRIPTION
1. make `WryWebViewPanel.Companion` public and modified 2 properties:
   - make `LOG_ENABLED` public and we can modifiy it's value.
   - add `NATIVE_LOGGER` property, and init the native logger in `WryWebViewPanel.Companion.init`。
2. add a property in `WryWebViewPanel`:
```kotlin
private val bridgeLogger: (String) -> Unit = { System.err.println(it) }
```
change the `log()` method:

```kotlin
    private fun log(message: String) {
        if (LOG_ENABLED) {
            bridgeLogger("[WryWebViewPanel] $message")
        }
    }
```