### PR TITLE
Add proxy support (desktop only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,26 @@ Commands:
 state.webSettings.customUserAgentString = "MyApp/1.2.3"
 ```
 
-Desktop note:
+
+
+### Proxy (desktop only)
+
+```kotlin
+// HTTP CONNECT Proxy
+state.webSettings.desktopWebSettings.proxyConfig = ProxyConfig.Http("proxy.tld", 8888)
+// SOCKS5 Proxy
+state.webSettings.desktopWebSettings.proxyConfig = ProxyConfig.Socks5("proxy.tld", 1080)
+```
+
+Proxy is only supported on Windows, macOS 14.0+ and Linux.
+
+Desktop note on both user-agent and proxy:
 
 * applied at creation time
 * changing it **recreates** the WebView (debounced)
 * JS context/history may be lost
 
-👉 Set it early.
+👉 Set them early.
 
 ---
 

--- a/demo-shared/src/commonMain/kotlin/io/github/kdroidfilter/webview/demo/DemoToolsPanel.kt
+++ b/demo-shared/src/commonMain/kotlin/io/github/kdroidfilter/webview/demo/DemoToolsPanel.kt
@@ -1,21 +1,9 @@
 package io.github.kdroidfilter.webview.demo
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -31,12 +19,17 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import composewebview.demo_shared.generated.resources.Res
 import io.github.kdroidfilter.webview.cookie.Cookie
+import io.github.kdroidfilter.webview.setting.ProxyConfig
 import io.github.kdroidfilter.webview.util.KLogSeverity
 import io.github.kdroidfilter.webview.web.WebViewNavigator
 import io.github.kdroidfilter.webview.web.WebViewState
@@ -87,6 +80,9 @@ internal fun DemoToolsPanel(
     onSetLogSeverity: (KLogSeverity) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
+    val desktopWebSettings = webViewState.webSettings.desktopWebSettings
+    var proxyType by remember { mutableStateOf("None") }
+    var proxyText by remember { mutableStateOf(desktopWebSettings.proxyConfig?.toString() ?: "") }
     Surface(modifier = modifier, color = MaterialTheme.colorScheme.surface) {
         Column(
             modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(12.dp),
@@ -375,6 +371,29 @@ internal fun DemoToolsPanel(
                     singleLine = true,
                     label = { Text("Custom User-Agent") },
                 )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = proxyText,
+                    onValueChange = { proxyText = it },
+                    singleLine = true,
+                    label = { Text("Proxy (desktop only)") },
+                )
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOf("None", "HTTP", "SOCKS5").forEach { type ->
+                        FilterChip(
+                            selected = proxyType == type,
+                            onClick = { proxyType = type },
+                            label = { Text(type) },
+                        )
+                    }
+                }
+                Button(
+                    onClick = {
+                        desktopWebSettings.proxyConfig = proxyText.ifBlank { null }?.parseProxyConfig(proxyType)
+                    }
+                ){
+                    Text("Set proxy")
+                }
             }
 
             SectionCard(title = "Logs") {
@@ -454,3 +473,14 @@ private fun inlineHtml(): String =
     </body>
     </html>
     """.trimIndent()
+
+private fun String.parseProxyConfig(proxyType: String): ProxyConfig? {
+    val host = substringBefore(":").ifBlank { null } ?: return null
+    val port = substringAfter(":").toIntOrNull() ?: return null
+    return when (proxyType) {
+        "None" -> null
+        "HTTP" -> ProxyConfig.Http(host, port)
+        "SOCKS5" -> ProxyConfig.Socks5(host, port)
+        else -> error("Invalid proxy type: $proxyType")
+    }
+}

--- a/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/PlatformWebSettings.kt
+++ b/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/PlatformWebSettings.kt
@@ -1,5 +1,8 @@
 package io.github.kdroidfilter.webview.setting
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 
 /**
@@ -13,9 +16,10 @@ sealed class PlatformWebSettings {
     ) : PlatformWebSettings()
 
     data class DesktopWebSettings(
-        var transparent: Boolean = true,
-        var proxyConfig: ProxyConfig? = null
-    ) : PlatformWebSettings()
+        var transparent: Boolean = true
+    ) : PlatformWebSettings() {
+        var proxyConfig: ProxyConfig? by mutableStateOf(null)
+    }
 
     data class IOSWebSettings(
         var opaque: Boolean = false,

--- a/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/PlatformWebSettings.kt
+++ b/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/PlatformWebSettings.kt
@@ -14,6 +14,7 @@ sealed class PlatformWebSettings {
 
     data class DesktopWebSettings(
         var transparent: Boolean = true,
+        var proxyConfig: ProxyConfig? = null
     ) : PlatformWebSettings()
 
     data class IOSWebSettings(

--- a/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/ProxyConfig.kt
+++ b/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/ProxyConfig.kt
@@ -1,0 +1,16 @@
+package io.github.kdroidfilter.webview.setting
+
+sealed class ProxyConfig {
+    abstract val host: String
+    abstract val port: Int
+
+    data class Http(
+        override val host: String,
+        override val port: Int
+    ) : ProxyConfig()
+
+    data class Socks5(
+        override val host: String,
+        override val port: Int
+    ) : ProxyConfig()
+}

--- a/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/ProxyConfig.kt
+++ b/webview-compose/src/commonMain/kotlin/io/github/kdroidfilter/webview/setting/ProxyConfig.kt
@@ -13,4 +13,6 @@ sealed class ProxyConfig {
         override val host: String,
         override val port: Int
     ) : ProxyConfig()
+
+    override fun toString() = "$host:$port"
 }

--- a/webview-compose/src/jvmMain/kotlin/io/github/kdroidfilter/webview/web/WebViewDesktop.kt
+++ b/webview-compose/src/jvmMain/kotlin/io/github/kdroidfilter/webview/web/WebViewDesktop.kt
@@ -46,7 +46,9 @@ actual fun ActualWebView(
     val currentOnDispose by rememberUpdatedState(onDispose)
     val scope = rememberCoroutineScope()
 
-    val proxyConfig = remember { state.webSettings.desktopWebSettings.proxyConfig }
+    val desiredProxyConfig = state.webSettings.desktopWebSettings.proxyConfig
+    var effectiveProxyConfig by remember { mutableStateOf(desiredProxyConfig) }
+
     val desiredUserAgent = state.webSettings.customUserAgentString?.trim()?.takeIf { it.isNotEmpty() }
     var effectiveUserAgent by remember { mutableStateOf(desiredUserAgent) }
 
@@ -57,8 +59,15 @@ actual fun ActualWebView(
         effectiveUserAgent = desiredUserAgent
     }
 
-    key(effectiveUserAgent) {
-        val nativeWebView = remember(state, factory) { factory(WebViewFactoryParam(state, userAgent = effectiveUserAgent, proxyConfig = proxyConfig)) }
+    LaunchedEffect(desiredProxyConfig) {
+        if (desiredProxyConfig == effectiveProxyConfig) return@LaunchedEffect
+        // Wry applies proxy config at creation time, so recreate the webview after a small debounce.
+        delay(400)
+        effectiveProxyConfig = desiredProxyConfig
+    }
+
+    key(effectiveUserAgent, effectiveProxyConfig) {
+        val nativeWebView = remember(state, factory) { factory(WebViewFactoryParam(state, userAgent = effectiveUserAgent, proxyConfig = effectiveProxyConfig)) }
 
         val desktopWebView =
             remember(nativeWebView, scope, webViewJsBridge) {

--- a/webview-compose/src/jvmMain/kotlin/io/github/kdroidfilter/webview/web/WebViewDesktop.kt
+++ b/webview-compose/src/jvmMain/kotlin/io/github/kdroidfilter/webview/web/WebViewDesktop.kt
@@ -17,18 +17,20 @@ import io.github.kdroidfilter.webview.jsbridge.WebViewJsBridge
 import io.github.kdroidfilter.webview.jsbridge.parseJsMessage
 import io.github.kdroidfilter.webview.request.WebRequest
 import io.github.kdroidfilter.webview.request.WebRequestInterceptResult
+import io.github.kdroidfilter.webview.setting.ProxyConfig
 import kotlinx.coroutines.delay
 
 actual class WebViewFactoryParam(
     val state: WebViewState,
     val fileContent: String = "",
     val userAgent: String? = null,
+    val proxyConfig: ProxyConfig? = null
 )
 
 actual fun defaultWebViewFactory(param: WebViewFactoryParam): NativeWebView =
     when (val content = param.state.content) {
-        is WebContent.Url -> NativeWebView(content.url, param.userAgent ?: param.state.webSettings.customUserAgentString)
-        else -> NativeWebView("about:blank", param.userAgent ?: param.state.webSettings.customUserAgentString)
+        is WebContent.Url -> NativeWebView(content.url, param.userAgent ?: param.state.webSettings.customUserAgentString, param.proxyConfig?.toJvmProxyConfig())
+        else -> NativeWebView("about:blank", param.userAgent ?: param.state.webSettings.customUserAgentString, param.proxyConfig?.toJvmProxyConfig())
     }
 
 @Composable
@@ -44,6 +46,7 @@ actual fun ActualWebView(
     val currentOnDispose by rememberUpdatedState(onDispose)
     val scope = rememberCoroutineScope()
 
+    val proxyConfig = remember { state.webSettings.desktopWebSettings.proxyConfig }
     val desiredUserAgent = state.webSettings.customUserAgentString?.trim()?.takeIf { it.isNotEmpty() }
     var effectiveUserAgent by remember { mutableStateOf(desiredUserAgent) }
 
@@ -55,7 +58,7 @@ actual fun ActualWebView(
     }
 
     key(effectiveUserAgent) {
-        val nativeWebView = remember(state, factory) { factory(WebViewFactoryParam(state, userAgent = effectiveUserAgent)) }
+        val nativeWebView = remember(state, factory) { factory(WebViewFactoryParam(state, userAgent = effectiveUserAgent, proxyConfig = proxyConfig)) }
 
         val desktopWebView =
             remember(nativeWebView, scope, webViewJsBridge) {
@@ -173,4 +176,9 @@ actual fun ActualWebView(
             }
         }
     }
+}
+
+internal fun ProxyConfig.toJvmProxyConfig(): io.github.kdroidfilter.webview.wry.JvmProxyConfig = when (this) {
+    is ProxyConfig.Http -> io.github.kdroidfilter.webview.wry.JvmProxyConfig.Http(host, port)
+    is ProxyConfig.Socks5 -> io.github.kdroidfilter.webview.wry.JvmProxyConfig.Socks5(host, port)
 }

--- a/wrywebview/Cargo.toml
+++ b/wrywebview/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main/rust/lib.rs"
 [dependencies]
 thiserror = "2.0.11"
 uniffi = "0.29.4"
-wry = "0.53.5"
+wry = { version = "0.53.5", features = ["mac-proxy"] }
 
 [profile.release]
 opt-level = "z"

--- a/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/JvmProxyConfig.kt
+++ b/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/JvmProxyConfig.kt
@@ -1,20 +1,23 @@
 package io.github.kdroidfilter.webview.wry
 
-sealed class ProxyConfig {
+/**
+ * JVM-specific proxy config
+ */
+sealed class JvmProxyConfig {
     abstract val host: String
     abstract val port: Int
 
     data class Http(
         override val host: String,
         override val port: Int
-    ) : ProxyConfig() {
+    ) : JvmProxyConfig() {
         override fun toProxy(): Proxy.Http = Proxy.Http(Address(host, port.toUShort()))
     }
 
     data class Socks5(
         override val host: String,
         override val port: Int
-    ) : ProxyConfig() {
+    ) : JvmProxyConfig() {
         override fun toProxy(): Proxy.Socks5 = Proxy.Socks5(Address(host, port.toUShort()))
     }
 

--- a/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/Proxy.kt
+++ b/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/Proxy.kt
@@ -1,0 +1,22 @@
+package io.github.kdroidfilter.webview.wry
+
+sealed class ProxyConfig {
+    abstract val host: String
+    abstract val port: Int
+
+    data class Http(
+        override val host: String,
+        override val port: Int
+    ) : ProxyConfig() {
+        override fun toProxy(): Proxy.Http = Proxy.Http(Address(host, port.toUShort()))
+    }
+
+    data class Socks5(
+        override val host: String,
+        override val port: Int
+    ) : ProxyConfig() {
+        override fun toProxy(): Proxy.Socks5 = Proxy.Socks5(Address(host, port.toUShort()))
+    }
+
+    internal abstract fun toProxy(): Proxy
+}

--- a/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/WryWebViewPanel.kt
+++ b/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/WryWebViewPanel.kt
@@ -9,12 +9,12 @@ import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import javax.swing.Timer
 import kotlin.concurrent.thread
-import kotlin.properties.Delegates
 
 
 class WryWebViewPanel(
     initialUrl: String,
     customUserAgent: String? = null,
+    proxyConfig: ProxyConfig? = null,
     private val bridgeLogger: (String) -> Unit = { System.err.println(it) }
 ) : JPanel() {
     private val host = SkikoInterop.createHost()
@@ -23,6 +23,7 @@ class WryWebViewPanel(
     private var parentIsWindow: Boolean = false
     private var pendingUrl: String = initialUrl
     private val customUserAgent: String? = customUserAgent?.trim()?.takeIf { it.isNotEmpty() }
+    private val proxy: Proxy? = proxyConfig?.toProxy()
     private var pendingUrlWithHeaders: String? = null
     private var pendingHeaders: Map<String, String> = emptyMap()
     private var pendingHtml: String? = null
@@ -348,7 +349,7 @@ class WryWebViewPanel(
             return try {
                 webviewId =
                     if (userAgent == null) {
-                        NativeBindings.createWebview(handleSnapshot, width, height, initialUrl, handler)
+                        NativeBindings.createWebview(handleSnapshot, width, height, initialUrl, handler, proxy)
                     } else {
                         NativeBindings.createWebviewWithUserAgent(
                             handleSnapshot,
@@ -356,7 +357,8 @@ class WryWebViewPanel(
                             height,
                             initialUrl,
                             userAgent,
-                            handler
+                            handler,
+                            proxy
                         )
                     }
                 updateBounds()
@@ -394,7 +396,7 @@ class WryWebViewPanel(
         thread(name = "wry-webview-create", isDaemon = true) {
             val createdId = try {
                 if (userAgent == null) {
-                    NativeBindings.createWebview(handleSnapshot, width, height, initialUrl, handler)
+                    NativeBindings.createWebview(handleSnapshot, width, height, initialUrl, handler, proxy)
                 } else {
                     NativeBindings.createWebviewWithUserAgent(
                         handleSnapshot,
@@ -402,7 +404,8 @@ class WryWebViewPanel(
                         height,
                         initialUrl,
                         userAgent,
-                        handler
+                        handler,
+                        proxy
                     )
                 }
             } catch (e: RuntimeException) {
@@ -702,8 +705,8 @@ class WryWebViewPanel(
 
 private object NativeBindings {
 
-    fun createWebview(parentHandle: ULong, width: Int, height: Int, url: String, handler: NavigationHandler): ULong {
-        return io.github.kdroidfilter.webview.wry.createWebview(parentHandle, width, height, url, handler)
+    fun createWebview(parentHandle: ULong, width: Int, height: Int, url: String, handler: NavigationHandler, proxy: Proxy?): ULong {
+        return io.github.kdroidfilter.webview.wry.createWebview(parentHandle, width, height, url, handler, proxy)
     }
 
     fun createWebviewWithUserAgent(
@@ -713,6 +716,7 @@ private object NativeBindings {
         url: String,
         userAgent: String,
         handler: NavigationHandler,
+        proxy: Proxy?
     ): ULong {
         return io.github.kdroidfilter.webview.wry.createWebviewWithUserAgent(
             parentHandle,
@@ -721,6 +725,7 @@ private object NativeBindings {
             url,
             userAgent,
             handler,
+            proxy
         )
     }
 

--- a/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/WryWebViewPanel.kt
+++ b/wrywebview/src/main/kotlin/io/github/kdroidfilter/webview/wry/WryWebViewPanel.kt
@@ -14,7 +14,7 @@ import kotlin.concurrent.thread
 class WryWebViewPanel(
     initialUrl: String,
     customUserAgent: String? = null,
-    proxyConfig: ProxyConfig? = null,
+    jvmProxyConfig: JvmProxyConfig? = null,
     private val bridgeLogger: (String) -> Unit = { System.err.println(it) }
 ) : JPanel() {
     private val host = SkikoInterop.createHost()
@@ -23,7 +23,7 @@ class WryWebViewPanel(
     private var parentIsWindow: Boolean = false
     private var pendingUrl: String = initialUrl
     private val customUserAgent: String? = customUserAgent?.trim()?.takeIf { it.isNotEmpty() }
-    private val proxy: Proxy? = proxyConfig?.toProxy()
+    private val proxy: Proxy? = jvmProxyConfig?.toProxy()
     private var pendingUrlWithHeaders: String? = null
     private var pendingHeaders: Map<String, String> = emptyMap()
     private var pendingHtml: String? = null

--- a/wrywebview/src/main/rust/lib.rs
+++ b/wrywebview/src/main/rust/lib.rs
@@ -487,6 +487,7 @@ pub fn create_webview(
            width, height,
            url,
            user_agent,
+           proxy.map(proxy_from_record),
            data_directory,
            zoom,
            transparent,
@@ -499,7 +500,6 @@ pub fn create_webview(
            autoplay,
            focused,
            nav_handler,
-           proxy
        )
    )
 }

--- a/wrywebview/src/main/rust/lib.rs
+++ b/wrywebview/src/main/rust/lib.rs
@@ -394,7 +394,7 @@ pub fn create_webview(
     }
 
     #[cfg(not(target_os = "linux"))]
-    run_on_main_thread(move || create_webview_inner(parent_handle, width, height, url, None, nav_handler))
+    run_on_main_thread(move || create_webview_inner(parent_handle, width, height, url, None, nav_handler, proxy.map(proxy_from_record)))
 }
 
 #[uniffi::export]
@@ -415,7 +415,7 @@ pub fn create_webview_with_user_agent(
     }
 
     #[cfg(not(target_os = "linux"))]
-    run_on_main_thread(move || create_webview_inner(parent_handle, width, height, url, user_agent,nav_handler))
+    run_on_main_thread(move || create_webview_inner(parent_handle, width, height, url, user_agent,nav_handler, proxy.map(proxy_from_record)))
 }
 
 // ============================================================================

--- a/wrywebview/src/main/rust/lib.rs
+++ b/wrywebview/src/main/rust/lib.rs
@@ -16,8 +16,9 @@ use wry::cookie::time::OffsetDateTime;
 use wry::cookie::{Cookie, Expiration, SameSite};
 use wry::http::header::HeaderName;
 use wry::http::{HeaderMap, HeaderValue};
-use wry::WebViewBuilder;
-
+use wry::{ProxyConfig, ProxyEndpoint, WebViewBuilder};
+use crate::Proxy::Http;
+use crate::Proxy::Socks5;
 pub use error::WebViewError;
 
 use handle::{make_bounds, raw_window_handle_from, RawWindow};
@@ -66,6 +67,18 @@ pub struct WebViewCookie {
     pub same_site: Option<CookieSameSite>,
     pub is_secure: Option<bool>,
     pub is_http_only: Option<bool>,
+}
+
+#[derive(uniffi::Enum)]
+pub enum Proxy {
+    Http(Address),
+    Socks5(Address),
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct Address {
+    pub host: String,
+    pub port: u16
 }
 
 fn header_map_from(headers: Vec<HttpHeader>) -> Result<HeaderMap, WebViewError> {
@@ -146,6 +159,13 @@ fn cookie_from_record(cookie: WebViewCookie) -> Result<Cookie<'static>, WebViewE
     Ok(builder.build())
 }
 
+fn proxy_from_record(proxy: Proxy) -> ProxyConfig {
+    match proxy {
+        Http(addr) => ProxyConfig::Http(ProxyEndpoint { host: addr.host, port: addr.port.to_string() }),
+        Socks5(addr) => ProxyConfig::Socks5(ProxyEndpoint { host: (addr.host), port: (addr.port.to_string()) })
+    }
+}
+
 use std::sync::atomic::AtomicBool;
 
 static LOG_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -216,6 +236,7 @@ fn create_webview_inner(
     url: String,
     user_agent: Option<String>,
     nav_handler: Option<Box<dyn NavigationHandler>>,
+    proxy_config: Option<ProxyConfig>,
 ) -> Result<u64, WebViewError> {
     let user_agent =
         user_agent.and_then(|ua| {
@@ -251,6 +272,10 @@ fn create_webview_inner(
     if let Some(ua) = user_agent {
         builder = builder.with_user_agent(ua);
     }
+
+    if let Some(proxy) = proxy_config {
+        builder = builder.with_proxy_config(proxy)
+    } 
 
     let webview = builder
         .with_navigation_handler(move |new_url| {
@@ -358,12 +383,13 @@ pub fn create_webview(
     width: i32,
     height: i32,
     url: String,
-    nav_handler: Option<Box<dyn NavigationHandler>>
+    nav_handler: Option<Box<dyn NavigationHandler>>,
+    proxy: Option<Proxy>
 ) -> Result<u64, WebViewError> {
     #[cfg(target_os = "linux")]
     {
         return run_on_gtk_thread(move || {
-            create_webview_inner(parent_handle, width, height, url, None, nav_handler)
+            create_webview_inner(parent_handle, width, height, url, None, nav_handler, proxy.map(proxy_from_record))
         });
     }
 
@@ -378,12 +404,13 @@ pub fn create_webview_with_user_agent(
     height: i32,
     url: String,
     user_agent: Option<String>,
-    nav_handler: Option<Box<dyn NavigationHandler>>
+    nav_handler: Option<Box<dyn NavigationHandler>>,
+    proxy: Option<Proxy>
 ) -> Result<u64, WebViewError> {
     #[cfg(target_os = "linux")]
     {
         return run_on_gtk_thread(move || {
-            create_webview_inner(parent_handle, width, height, url, user_agent, nav_handler)
+            create_webview_inner(parent_handle, width, height, url, user_agent, nav_handler, proxy.map(proxy_from_record))
         });
     }
 


### PR DESCRIPTION
# Proxy support on Desktop

This pull request enables HTTP and SOCKS5 proxy support for desktop platforms (Windows, macOS and Linux). Android only supports a global proxy setting for all WebViews with `ProxyController` and iOS with `WKWebView` doesn't seem to support it at all. I tested this change only on Linux.

## Changes

- Add docs

### Public API

- Add `jvmProxyConfig` parameter to `WryWebViewPanel`. This change could be potentially breaking.
- Add `proxyConfig` to `PlatformWebSettings.DesktopWebSettings`
- Add `ProxyConfig`
- Add `JvmProxyConfig`

### Internal API

- Add `proxy` option to `create_webview` and `create_webview_inner` in Rust
- Update `NativeBindings`
- Some internal helper methods in Rust and Kotlin