### PR TITLE
Fix WebView focus on Windows by using native wry focus API

### DIFF
--- a/wrywebview/src/main/rust/lib.rs
+++ b/wrywebview/src/main/rust/lib.rs
@@ -778,9 +778,7 @@ fn focus_inner(id: u64) -> Result<(), WebViewError> {
             wry_log!("[wrywebview] gtk grab_focus called");
         }
 
-        webview
-            .evaluate_script("document.documentElement.focus(); window.focus();")
-            .map_err(WebViewError::from)
+        webview.focus().map_err(WebViewError::from)
     })
 }
 


### PR DESCRIPTION
This PR fixes a Windows issue where the WebView did not reliably receive focus when requested.

Switched `focus_inner` from the JavaScript fallback to wry’s native `focus()` method, which correctly applies platform-level focus on Windows while keeping behavior consistent on the other platforms.

See https://docs.rs/wry/0.54.2/wry/struct.WebView.html#method.focus