### PR TITLE
close: issue #2 is a JVM Compose/JCEF z-order interop bug, not addressable in AndroidWebView.kt

### DIFF
--- a/webview-compose/src/androidMain/kotlin/io/github/kdroidfilter/webview/web/AndroidWebView.kt
+++ b/webview-compose/src/androidMain/kotlin/io/github/kdroidfilter/webview/web/AndroidWebView.kt
@@ -6,6 +6,7 @@ import io.github.kdroidfilter.webview.jsbridge.WebViewJsBridge
 import io.github.kdroidfilter.webview.jsbridge.parseJsMessage
 import io.github.kdroidfilter.webview.util.KLogger
 import kotlinx.coroutines.CoroutineScope
+import android.annotation.SuppressLint
 
 internal class AndroidWebView(
     override val nativeWebView: WebView,
@@ -98,6 +99,7 @@ internal class AndroidWebView(
     }
 
     override fun initJsBridge(webViewJsBridge: WebViewJsBridge) {
+        @SuppressLint("AddJavascriptInterface")
         nativeWebView.addJavascriptInterface(this, "androidJsBridge")
     }
 


### PR DESCRIPTION
## Closing - issue #2 is not addressable in this file

Issue #2 ("Cannot overlay Compose elements on top of WebView") is a
JVM-target Compose / JCEF (Wry) z-order interop bug. It only
reproduces on the JVM/Desktop source set with
`compose.swing.render.on.graphics` and `compose.interop.blending`
enabled. The fix has to live in the JCEF / Skiko window-composition
path (or be filed upstream against JetBrains Compose Multiplatform /
Wry), not in
`webview-compose/src/androidMain/kotlin/.../web/AndroidWebView.kt`,
which is the Android-only source set and has no z-order code.

The auto-generated draft of this PR added cosmetic edits to that
unrelated Android file. Shipping it would imply #2 had been fixed
when, in fact, the JVM rendering pipeline is untouched. Closing in
favour of keeping #2 open as the place to track the real interop fix.
