### PR TITLE
Publish releases from macOS so iOS targets resolve

### DIFF
--- a/.github/workflows/publish-on-maven.yml
+++ b/.github/workflows/publish-on-maven.yml
@@ -30,10 +30,28 @@ jobs:
 
   publish:
     needs: build-natives
-    runs-on: ubuntu-latest
+    # MUST stay on macOS: iosArm64 / iosSimulatorArm64 are disabled on any other
+    # host, and Kotlin then writes the root module metadata with Gradle-default
+    # coordinates for them (`composewebview:webview-compose-iosarm64:unspecified`),
+    # which makes the release unresolvable for iOS consumers (issue #51).
+    # :webview-compose:verifyPublicationCoordinates guards against a regression.
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26+ (Compose 1.11 needs iOS 26 SDK)
+        run: |
+          # Same selection as the iOS jobs in pr-build-check.yml.
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1 || true)
+          if [ -z "$XCODE" ]; then
+            XCODE=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1 || true)
+          fi
+          if [ -n "$XCODE" ]; then
+            echo "Using $XCODE"
+            sudo xcode-select -s "$XCODE"
+          fi
+          xcodebuild -version
 
       - name: Download native artifacts
         uses: actions/download-artifact@v4

--- a/webview-compose/build.gradle.kts
+++ b/webview-compose/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:OptIn(ExperimentalWasmDsl::class)
 
 import com.vanniktech.maven.publish.KotlinMultiplatform
+import groovy.json.JsonSlurper
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
@@ -207,4 +208,56 @@ mavenPublishing {
         name.set("ComposeWebView")
         description.set("Compose Multiplatform WebView library for Desktop, Android and iOS")
     }
+}
+
+// The root KMP module metadata redirects every target variant to a sibling module
+// through an `available-at` entry. Targets that are disabled on the publishing host
+// (Apple targets anywhere but macOS) keep Gradle's default project coordinates, so
+// the release ships pointing at `composewebview:webview-compose-iosarm64:unspecified`
+// and no iOS consumer can resolve it (issue #51). Fail the publish instead.
+val verifyPublicationCoordinates by tasks.registering {
+    description = "Checks that the KMP root module metadata only points at modules being published"
+    group = "verification"
+
+    val metadataFile = tasks.named<GenerateModuleMetadata>(
+        "generateMetadataFileForKotlinMultiplatformPublication"
+    ).flatMap { it.outputFile }
+
+    inputs.file(metadataFile)
+
+    doLast {
+        @Suppress("UNCHECKED_CAST")
+        val root = JsonSlurper().parse(metadataFile.get().asFile) as Map<String, Any>
+
+        @Suppress("UNCHECKED_CAST")
+        val component = root["component"] as Map<String, Any>
+        val group = component["group"]
+        val version = component["version"]
+
+        @Suppress("UNCHECKED_CAST")
+        val variants = root["variants"] as? List<Map<String, Any>> ?: emptyList()
+        val dangling = variants.mapNotNull { variant ->
+            @Suppress("UNCHECKED_CAST")
+            val at = variant["available-at"] as? Map<String, Any> ?: return@mapNotNull null
+            if (at["group"] == group && at["version"] == version) return@mapNotNull null
+            "${variant["name"]} -> ${at["group"]}:${at["module"]}:${at["version"]}"
+        }
+
+        check(dangling.isEmpty()) {
+            buildString {
+                appendLine("Root module metadata points at modules outside this publication:")
+                dangling.forEach { appendLine("  $it") }
+                appendLine("Expected $group:*:$version.")
+                append(
+                    "Publish from a host that can build every declared target " +
+                        "(macOS is required for the iOS targets)."
+                )
+            }
+        }
+        logger.lifecycle("Publication coordinates OK: ${variants.size} variants under $group:*:$version")
+    }
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    dependsOn(verifyPublicationCoordinates)
 }


### PR DESCRIPTION
## Problem

`dev.nucleusframework:composewebview:1.0.0` cannot be resolved by any KMP project with Apple targets (#51):

```
> Could not find composewebview:webview-compose-iosarm64:unspecified.
```

The `publish` job ran on `ubuntu-latest`, where `iosArm64` / `iosSimulatorArm64` are disabled. Kotlin still emits their variants in the root Gradle module metadata, but with Gradle's *default* project coordinates instead of the publication's. The shipped `composewebview-1.0.0.module` therefore contains:

```json
"available-at": {
  "group": "composewebview",
  "module": "webview-compose-iosarm64",
  "version": "unspecified"
}
```

while every other target correctly points at `dev.nucleusframework:composewebview-*:1.0.0`. The iOS klibs were never published at all.

## Fix

- `publish` now runs on `macos-15`, reusing the Xcode selection from the iOS jobs in `pr-build-check.yml`. Natives keep coming from the `build-natives` matrix artifacts, so nothing else about the job changes.
- New `:webview-compose:verifyPublicationCoordinates` reads the generated root `module.json` and fails if any `available-at` entry falls outside the group/version being published. It is wired as a dependency of every `AbstractPublishToMaven` task, so a wrong publish host can never ship a dangling module again.

## Verification

**1. Guard rejects the broken release** — fed the real `composewebview-1.0.0.module` from Maven Central:

```
> Root module metadata points at modules outside this publication:
    iosArm64ApiElements-published -> composewebview:webview-compose-iosarm64:unspecified
    ... (8 entries)
  Expected dev.nucleusframework:*:1.0.0.
```

and passes on a macOS publish: `Publication coordinates OK: 20 variants under dev.nucleusframework:*:0.1.0-SNAPSHOT`.

**2. Consumer project, issue reproduced then fixed.** A scratch KMP module with `iosArm64` + `iosSimulatorArm64` calling `rememberWebViewState` / `WebView` from `commonMain`:

| dependency | `:shared:compileKotlinIosArm64` |
| --- | --- |
| `composewebview:1.0.0` (Maven Central) | ❌ `Could not find composewebview:webview-compose-iosarm64:unspecified` |
| `composewebview:1.0.1-e2e` (published from macOS) | ✅ |

With the fixed publication, `:shared:dependencies --configuration iosArm64CInterop` — the exact configuration from the issue — resolves to `dev.nucleusframework:composewebview-iosarm64:1.0.1-e2e`, and `:shared:linkDebugFrameworkIosSimulatorArm64` links `shared.framework` successfully.

**3. No regression** — `./gradlew :e2e-desktop:run` on macOS: `SUITE_FINISHED passed=true` (full visual suite, real WKWebView).

Closes #51