### PR TITLE
Raise the Central Portal upload timeout

### DIFF
--- a/.github/workflows/publish-on-maven.yml
+++ b/.github/workflows/publish-on-maven.yml
@@ -97,8 +97,16 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # SONATYPE_CONNECT_TIMEOUT_SECONDS defaults to 60s, which is the OkHttp
+      # read timeout on the bundle upload. The Central Portal regularly takes
+      # longer to answer, and a timed-out upload still leaves a live deployment
+      # behind — so the retry then fails with "currently being published in
+      # another deployment" and the release needs manual cleanup.
       - name: Publish to Maven Central
-        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+        run: >
+          ./gradlew publishAndReleaseToMavenCentral
+          -PSONATYPE_CONNECT_TIMEOUT_SECONDS=600
+          --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVENCENTRALUSERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVENCENTRALPASSWORD }}


### PR DESCRIPTION
Follow-up to #52. The `v1.0.1` publish job failed:

```
FAILURE: Build failed with an exception.
* What went wrong:
Failed to stop service 'maven-central-build-service'.
> timeout
```

exactly 60 s after the bundle upload started. `SONATYPE_CONNECT_TIMEOUT_SECONDS` defaults to 60 and the plugin uses it as the OkHttp **read** timeout on `api/v1/publisher/upload`, so a slow Portal response fails the build even though the upload succeeded.

That is what happened here — the deployment was live on the Portal, so re-running the job produced:

```
> Deployment a028abb8-... failed validation:
  * Component with coordinate 'dev.nucleusframework:composewebview-jvm:1.0.1'
    is currently being published in another deployment (8b0658e6-...)
```

Giving the Portal 10 minutes to answer avoids both the spurious failure and the duplicate-deployment cleanup it causes. No behaviour change on a fast response.